### PR TITLE
Fix equo query to prevent dependencies being reinstalled

### DIFF
--- a/builder
+++ b/builder
@@ -69,7 +69,7 @@ sub calculate_missing {
 
     #taking only the 4th column of output as key of the hashmap
     my %installed_packs =
-      map { ( split( /\s/, $_ ) )[3] => 1 } @Installed_Packages;
+      map { $_ => 1 } @Installed_Packages;
     my %available_packs = map { $_ => 1 } available_packages();
 
 # removing from packages the one that are already installed and keeping only the available in the entropy repositories

--- a/builder
+++ b/builder
@@ -63,7 +63,7 @@ sub calculate_missing {
     # Getting the package dependencies and the installed packages
     say "[$package] Getting the package dependencies and the installed packages";
     my @Packages = package_deps( $package, $depth, 1 );
-    my @Installed_Packages = qx/equo q --quiet list installed/;
+    my @Installed_Packages = qx/equo q list installed --quiet/;
     chomp(@Installed_Packages);
     say "[$package] Getting the package dependencies and the installed packages";
 


### PR DESCRIPTION
Call to equo query puts arg '--quiet' in the wrong place, receiving
prettified output which doesn't match string comparisons against
package names, leading to all dependencies being reinstalled every
time. This commit puts the --quiet arg in to correct place so that
only missing dependencies are installed.
